### PR TITLE
fix markdown

### DIFF
--- a/input/pagecontent/StructureDefinition-ext-myExtension-intro.md
+++ b/input/pagecontent/StructureDefinition-ext-myExtension-intro.md
@@ -1,2 +1,2 @@
-###Introduction
+### Introduction
 Introductory guidance on myExtension

--- a/input/pagecontent/spec.md
+++ b/input/pagecontent/spec.md
@@ -1,2 +1,2 @@
-###A Heading
+### A Heading
 You can also use markdown if that's your thing


### PR DESCRIPTION
Without the space, the headings aren't interpretted as headers.  For example, see https://build.fhir.org/ig/FHIR/sample-ig/spec.html