### PR TITLE
Add -f and --force flag to _updatePublisher.bat

### DIFF
--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -1,7 +1,19 @@
 @ECHO OFF
+
+SETLOCAL
+
 SET dlurl=https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar
 SET publisher_jar=org.hl7.fhir.publisher.jar
 SET input_cache_path=%CD%\input-cache\
+
+:processflags
+SET ARG=%1
+IF DEFINED ARG (
+	IF "%ARG%"=="-f" SET FORCE=true
+	IF "%ARG%"=="--force" SET FORCE=true
+	SHIFT
+	GOTO processflags
+)
 
 FOR %%x IN ("%CD%") DO SET upper_path=%%~dpx
 
@@ -26,6 +38,10 @@ IF NOT EXIST "%input_cache_path%%publisher_jar%" (
 )
 
 :create
+IF DEFINED FORCE (
+	MKDIR "%input_cache_path%" 2> NUL
+	GOTO:download
+)
 ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
 SET /p create="Ok? (Y/N) "
 IF /I "%create%"=="Y" (
@@ -35,6 +51,7 @@ IF /I "%create%"=="Y" (
 GOTO:done
 
 :upgrade
+IF DEFINED FORCE GOTO:download
 SET /p overwrite="Overwrite %jarlocation%? (Y/N) "
 IF /I "%overwrite%"=="Y" (
 	GOTO:download
@@ -70,4 +87,4 @@ ECHO This script does not yet support Windows %winver%.  Please ask for help on 
 GOTO done
 
 :done
-PAUSE
+IF NOT DEFINED FORCE PAUSE


### PR DESCRIPTION
This adds a `-f` and `--force` flag to `_updatePublisher.bat` to allow a forced, non-interactive download. This is the same functionality that was added to `_updatePublisher.sh` in https://github.com/FHIR/sample-ig/pull/16, and related to issue #15, but for Windows users.