### PR TITLE
Self updating scripts

### DIFF
--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -7,7 +7,7 @@ SET publisher_jar=org.hl7.fhir.publisher.jar
 SET input_cache_path=%CD%\input-cache\
 SET skipPrompts=false
 
-set update_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_updatePublisher.bat
+set update_bat_url=https://raw.githubusercontent.com/costateixeira/sample-ig/self-updating-scripts/_updatePublisher.bat
 set gen_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_genonce.bat
 set gencont_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_gencontinuous.bat
 set gencont_sh_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_gencontinuous.sh

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -19,6 +19,15 @@ IF "%~1"=="/f" SET skipPrompts=true
 ECHO "%skipPrompts%"
 
 
+ECHO Checking internet connection...
+PING tx.fhir.org -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+ECHO We're offline, nothing to do...
+GOTO end
+
+:isonline
+ECHO We're online
+
+
 :processflags
 SET ARG=%1
 IF DEFINED ARG (
@@ -41,19 +50,19 @@ IF NOT EXIST "%input_cache_path%%publisher_jar%" (
 		ECHO IG Publisher FOUND in parent folder
 		SET jarlocation="%upper_path%%publisher_jar%"
 		SET jarlocationname=Parent folder
-		GOTO:upgrade
+		GOTO upgrade
 	)
 ) ELSE (
 	ECHO IG Publisher FOUND in input-cache
 	SET jarlocation="%input_cache_path%%publisher_jar%"
 	SET jarlocationname=Input Cache
-	GOTO:upgrade
+	GOTO upgrade
 )
 
 :create
 IF DEFINED FORCE (
 	MKDIR "%input_cache_path%" 2> NUL
-	GOTO:download
+	GOTO download
 )
 ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
 IF "%skipPrompts%"=="true" (
@@ -61,11 +70,11 @@ IF "%skipPrompts%"=="true" (
 ) ELSE (
 	SET /p create="Ok? (Y/N) "
 )
-IF /I %create%=="Y" (
+IF /I "%create%"=="Y" (
 	MKDIR "%input_cache_path%" 2> NUL
-	GOTO:download
+	GOTO download
 )
-GOTO:done
+GOTO done
 
 :upgrade
 IF "%skipPrompts%"=="true" (
@@ -74,10 +83,10 @@ IF "%skipPrompts%"=="true" (
 	SET /p overwrite="Overwrite %jarlocation%? (Y/N) "
 )
 
-IF /I %overwrite%=="Y" (
-	GOTO:download
+IF /I "%overwrite%"=="Y" (
+	GOTO download
 )
-GOTO:done
+GOTO done
 
 :download
 ECHO Downloading most recent publisher to %jarlocationname% - it's ~100 MB, so this may take a bit
@@ -98,33 +107,71 @@ CALL POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object Sys
 GOTO done
 
 :win7
-CALL bitsadmin /transfer GetPublisher /download /priority normal "%dlurl%" "%jarlocation%"
+rem this may be triggering the antivirus - bitsadmin.exe is a known threat
+rem CALL bitsadmin /transfer GetPublisher /download /priority normal "%dlurl%" "%jarlocation%"
+
+rem this didn't work in win 10
+rem CALL Start-BitsTransfer /priority normal "%dlurl%" "%jarlocation%"
+
+rem this should work - untested
+call (New-Object Net.WebClient).DownloadFile('%dlurl%', '%jarlocation%')
 GOTO done
 
 :win8.1
 :win8
 :vista
-ECHO This script does not yet support Windows %winver%.  Please ask for help on http://chat.fhir.org
 GOTO done
 
+
+
 :done
+
+
+
+
+ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
+IF "%skipPrompts%"=="true" (
+	SET updateScripts="Y"
+) ELSE (
+	SET /p updateScripts="Update scripts? (Y/N) "
+)
+IF /I "%updateScripts%"=="Y" (
+	GOTO scripts
+)
+GOTO end
+
+
+:scripts
 
 REM Download all batch files (and this one with a new name)
 
 SETLOCAL DisableDelayedExpansion
 
 REM ==== For getting the sources online...
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_bat_url%\",\"_updatePublisher.new.bat\") } else { Invoke-WebRequest -Uri "%update_bat_url%" -Outfile "_updatePublisher.new.bat" }
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_bat_url%\",\"_genonce.bat\") } else { Invoke-WebRequest -Uri "%gen_bat_url%" -Outfile "_genonce.bat" }
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_bat_url%\",\"_gencontinuous.bat\") } else { Invoke-WebRequest -Uri "%gencont_bat_url%" -Outfile "_gencontinuous.bat" }
 
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_sh_url%\",\"_updatePublisher.sh\") } else { Invoke-WebRequest -Uri "%update_sh_url%" -Outfile "_updatePublisher.new.sh" }
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_sh_url%\",\"_genonce.sh\") } else { Invoke-WebRequest -Uri "%gen_sh_url%" -Outfile "_genonce.sh" }
-POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_sh_url%\",\"_gencontinuous.sh\") } else { Invoke-WebRequest -Uri "%gencont_sh_url%" -Outfile "_gencontinuous.sh" }
 
+rem POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_sh_url%\",\"_updatePublisher.sh\") } else { Invoke-WebRequest -Uri "%update_sh_url%" -Outfile "_updatePublisher.new.sh" }
+
+
+rem POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_bat_url%\",\"_genonce.bat\") } else { Invoke-WebRequest -Uri "%gen_bat_url%" -Outfile "_genonce.bat" }
+
+rem POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_bat_url%\",\"_gencontinuous.bat\") } else { Invoke-WebRequest -Uri "%gencont_bat_url%" -Outfile "_gencontinuous.bat" }
+
+rem POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_sh_url%\",\"_genonce.sh\") } else { Invoke-WebRequest -Uri "%gen_sh_url%" -Outfile "_genonce.sh" }
+
+rem POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_sh_url%\",\"_gencontinuous.sh\") } else { Invoke-WebRequest -Uri "%gencont_sh_url%" -Outfile "_gencontinuous.sh" }
+
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_bat_url%\",\"_updatePublisher.new.bat\") } else { Invoke-WebRequest -Uri "%update_bat_url%" -Outfile "_updatePublisher.new.bat" }
+
+if %ERRORLEVEL% == 0 goto next
+echo "Errors encountered during execution.  Exited with status: %errorlevel%"
+goto end
+:next
 ECHO Updating this file...
-start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updatePublisher.new.bat" ^&^& exit
+start copy /y "_updatePublisher.new.bat" "_updatePublisher2.bat" ^&^& del "_updatePublisher.new.bat" ^&^& exit
 REM ============================
+
+:end
 
 IF "%skipPrompts%"=="true" (
   PAUSE

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -7,7 +7,7 @@ SET publisher_jar=org.hl7.fhir.publisher.jar
 SET input_cache_path=%CD%\input-cache\
 SET skipPrompts=false
 
-set update_bat_url=https://raw.githubusercontent.com/costateixeira/sample-ig/self-updating-scripts/_updatePublisher.bat
+set update_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_updatePublisher.bat
 set gen_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_genonce.bat
 set gencont_bat_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_gencontinuous.bat
 set gencont_sh_url=https://raw.githubusercontent.com/FHIR/sample-ig/master/_gencontinuous.sh

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -168,7 +168,7 @@ echo "Errors encountered during execution.  Exited with status: %errorlevel%"
 goto end
 :next
 ECHO Updating this file...
-start copy /y "_updatePublisher.new.bat" "_updatePublisher2.bat" ^&^& del "_updatePublisher.new.bat" ^&^& exit
+start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updatePublisher.new.bat" ^&^& exit
 REM ============================
 
 :end


### PR DESCRIPTION
Enable self-updating scripts.
Commented out the Windows 7 part (bitsadmin could trigger virus protection)
Currently only updates _updatePublisher.bat - will add others if test is OK
Current commit gets the source bat file from my branch, not from FHIR - this way it already works even before merge.