### PR TITLE
Fix shebang in _updatePublisher.sh

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 pubsource=https://github.com/HL7/fhir-ig-publisher/releases/latest/download/
 publisher_jar=publisher.jar
 dlurl=$pubsource$publisher_jar


### PR DESCRIPTION
It looks like the shebang in `_updatePublisher.sh` somehow lost the (very necessary) `!`.  As a result, running it produced this error:
![image](https://user-images.githubusercontent.com/2278253/94692299-6556c200-0300-11eb-8fae-45a50f0e3279.png)

Adding back the `!` fixes it.