### PR TITLE
Fix an error while CI finishes cmd returns code 255

### DIFF
--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -216,4 +216,4 @@ start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updat
 
 IF "%skipPrompts%"=="y" (
   PAUSE
-}
+)

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -214,6 +214,6 @@ start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updat
 :end
 
 
-IF "%skipPrompts%"=="true" (
+IF "%skipPrompts%"=="y" (
   PAUSE
 }


### PR DESCRIPTION
While CI finishes _updatePublisher.bat job, cmd doesn't exit with 0 but 255. The command I use is "_updatePublisher.bat /f".