### PR TITLE
fix(updatePublisher): linux os type check

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -32,7 +32,7 @@ done
 
 echo "Checking internet connection"
 case "$OSTYPE" in
-	linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 1000 >/dev/null ;;
+	linux* ) ping tx.fhir.org -4 -c 1 -w 1000 >/dev/null ;;
   darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
 	*) echo "unknown: $OSTYPE"; exit 1 ;;
 esac


### PR DESCRIPTION
## Problem
When using the _updatePublisher shell script on Linux Alpine, the os type check fails since the environment variable OSTYPE return the value "linux-musl" and not "linux-gnu". 

## Description
This PR aims to broaden the os type check for linux
